### PR TITLE
Fixed error y_predicted['labels']

### DIFF
--- a/Iris_classification/Iris_classification.ipynb
+++ b/Iris_classification/Iris_classification.ipynb
@@ -121,7 +121,7 @@
     "# Predict\n",
     "y_predicted = automl.predict(X_test)\n",
     "\n",
-    "result = pd.DataFrame({\"Predicted\": y_predicted[\"label\"], \"Target\": np.array(y_test)})\n",
+    "result = pd.DataFrame({\"Predicted\": y_predicted, \"Target\": np.array(y_test)})\n",
     "filtro = result.Predicted == result.Target\n",
     "print(filtro.value_counts(normalize=True))"
    ]


### PR DESCRIPTION
Calling `y_predicted['labels']` returns an error because `y_predicted` is already of type `numpy.ndarray`